### PR TITLE
Display full route contact data

### DIFF
--- a/src/pages/StatusPage.tsx
+++ b/src/pages/StatusPage.tsx
@@ -3,9 +3,11 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Progress } from '@/components/ui/progress';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { offlineStorage } from '@/lib/offline-storage';
-import { CheckCircle2, AlertTriangle, Loader2 } from 'lucide-react';
+import { CheckCircle2, AlertTriangle, Loader2, User, Mail, Phone, Building } from 'lucide-react';
 import CacheStatus from '@/components/ui/CacheStatus';
+import type { OfflineJourney } from '@/lib/offline-storage';
 
 export default function StatusPage() {
   const [stats, setStats] = useState<null | {
@@ -16,13 +18,26 @@ export default function StatusPage() {
     completedJourneys: number;
     lastSync: Date | null;
   }>(null);
+  const [journeys, setJourneys] = useState<OfflineJourney[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    offlineStorage.getLocalStats().then(s => {
-      setStats(s);
-      setLoading(false);
-    });
+    const loadData = async () => {
+      try {
+        const [statsData, journeysData] = await Promise.all([
+          offlineStorage.getLocalStats(),
+          offlineStorage.getAllJourneys()
+        ]);
+        setStats(statsData);
+        setJourneys(journeysData);
+      } catch (error) {
+        console.error('Error loading status data:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadData();
   }, []);
 
   if (loading || !stats) {
@@ -37,8 +52,17 @@ export default function StatusPage() {
   const allSynced = stats.pendingSync === 0 && stats.failedSync === 0;
   const percentSynced = stats.totalJourneys === 0 ? 100 : Math.round((stats.syncedJourneys / stats.totalJourneys) * 100);
 
+  // Filter journeys that have contact information
+  const journeysWithContacts = journeys.filter(journey => journey.contact && (
+    journey.contact.fullName || 
+    journey.contact.email || 
+    journey.contact.phone || 
+    journey.contact.company
+  ));
+
   return (
-    <div className="max-w-xl mx-auto py-16 px-4 space-y-6">
+    <div className="max-w-6xl mx-auto py-16 px-4 space-y-6">
+      {/* Sync Status Card */}
       <Card className="shadow-xl border-2 border-blue-100">
         <CardHeader className="flex flex-col items-center gap-2 pb-2">
           <CardTitle className="text-3xl font-bold tracking-tight">Sync Status</CardTitle>
@@ -102,6 +126,97 @@ export default function StatusPage() {
                 </AlertDescription>
               </div>
             </Alert>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Contacts Data Card */}
+      <Card className="shadow-xl border-2 border-green-100">
+        <CardHeader className="flex flex-col items-center gap-2 pb-2">
+          <CardTitle className="text-3xl font-bold tracking-tight">Saved Contacts</CardTitle>
+          <CardDescription className="text-center text-base text-gray-500">
+            All contact information collected from completed journeys
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="pt-0">
+          {journeysWithContacts.length === 0 ? (
+            <div className="text-center py-8 text-gray-500">
+              <User className="w-12 h-12 mx-auto mb-4 text-gray-300" />
+              <p className="text-lg">No contacts saved yet</p>
+              <p className="text-sm">Complete some journeys to see contact data here</p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="font-semibold">Name</TableHead>
+                    <TableHead className="font-semibold">Email</TableHead>
+                    <TableHead className="font-semibold">Phone</TableHead>
+                    <TableHead className="font-semibold">Company</TableHead>
+                    <TableHead className="font-semibold">Sync Status</TableHead>
+                    <TableHead className="font-semibold">Completed</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {journeysWithContacts.map((journey) => (
+                    <TableRow key={journey.localId} className="hover:bg-gray-50">
+                      <TableCell className="font-medium">
+                        <div className="flex items-center gap-2">
+                          <User className="w-4 h-4 text-gray-400" />
+                          {journey.contact?.fullName || '—'}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <Mail className="w-4 h-4 text-gray-400" />
+                          {journey.contact?.email || '—'}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <Phone className="w-4 h-4 text-gray-400" />
+                          {journey.contact?.phone || '—'}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <Building className="w-4 h-4 text-gray-400" />
+                          {journey.contact?.company || '—'}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge 
+                          variant={
+                            journey.syncStatus === 'synced' ? 'default' :
+                            journey.syncStatus === 'pending' ? 'secondary' : 'destructive'
+                          }
+                        >
+                          {journey.syncStatus}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        {journey.completedAt ? (
+                          <span className="text-sm text-gray-600">
+                            {new Date(journey.completedAt).toLocaleDateString()}
+                          </span>
+                        ) : (
+                          <span className="text-sm text-gray-400">Incomplete</span>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+          
+          {journeysWithContacts.length > 0 && (
+            <div className="mt-4 text-center">
+              <Badge variant="outline" className="text-sm">
+                {journeysWithContacts.length} contact{journeysWithContacts.length !== 1 ? 's' : ''} saved
+              </Badge>
+            </div>
           )}
         </CardContent>
       </Card>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add a table to the status page to display full contact data from locally saved journeys.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The existing status page only showed counts of journeys. This PR enhances it by fetching all journey data and presenting a detailed table of contacts, including name, email, phone, company, sync status, and completion date, fulfilling the user's request for full data visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8eeb2f3-de63-48e0-9e6a-88fc3cc33925">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8eeb2f3-de63-48e0-9e6a-88fc3cc33925">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>